### PR TITLE
Feat/v2/url sync

### DIFF
--- a/components/designSystem/SmolAddressInput.tsx
+++ b/components/designSystem/SmolAddressInput.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useAddressBook} from 'contexts/useAddressBook';
 import {getEnsName} from 'viem/ens';
 import {IconAppAddressBook} from '@icons/IconApps';
@@ -20,7 +20,7 @@ export type TInputAddressLike = {
 	address: TAddress | undefined;
 	label: string;
 	isValid: boolean | 'undetermined';
-	source?: 'typed' | 'addressBook' | 'defaultValue';
+	source?: 'typed' | 'addressBook' | 'defaultValue' | 'urlQuery';
 	error?: string;
 };
 export const defaultInputAddressLike: TInputAddressLike = {
@@ -33,9 +33,13 @@ export const defaultInputAddressLike: TInputAddressLike = {
 type TAddressInput = {
 	onSetValue: (value: TInputAddressLike) => void;
 	value: TInputAddressLike;
+	/**
+	 * Should be present if we want to make use of query params syncing
+	 */
+	initialValue?: string;
 };
 
-export function SmolAddressInput({onSetValue, value}: TAddressInput): ReactElement {
+export function SmolAddressInput({onSetValue, value, initialValue}: TAddressInput): ReactElement {
 	const {onOpenCurtain, getEntry, getCachedEntry} = useAddressBook();
 	const [isFocused, set_isFocused] = useState<boolean>(false);
 	const [isCheckingValidity, set_isCheckingValidity] = useState<boolean>(false);
@@ -171,6 +175,13 @@ export function SmolAddressInput({onSetValue, value}: TAddressInput): ReactEleme
 		},
 		[actions]
 	);
+
+	useEffect(() => {
+		if (!initialValue) {
+			return;
+		}
+		onChange(initialValue);
+	}, []);
 
 	const onSelectItem = useCallback((item: TAddressBookEntry): void => {
 		currentInput.current = item.label || item.ens || toAddress(item.address);

--- a/components/designSystem/SmolTokenAmountInput.tsx
+++ b/components/designSystem/SmolTokenAmountInput.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import {getNewInput} from 'components/sections/Send/useSend';
+import {getNewInput} from 'components/sections/Send/useSendFlow';
 import {useBalancesCurtain} from 'contexts/useBalancesCurtain';
 import useWallet from 'contexts/useWallet';
 import {IconChevron} from '@icons/IconChevron';

--- a/components/designSystem/SmolTokenAmountInput.tsx
+++ b/components/designSystem/SmolTokenAmountInput.tsx
@@ -3,9 +3,10 @@ import {getNewInput} from 'components/sections/Send/useSendFlow';
 import {useBalancesCurtain} from 'contexts/useBalancesCurtain';
 import useWallet from 'contexts/useWallet';
 import {IconChevron} from '@icons/IconChevron';
+import {useDeepCompareEffect} from '@react-hookz/web';
 import {percentOf} from '@utils/tools.math';
 import {cl} from '@yearn-finance/web-lib/utils/cl';
-import {parseUnits, toBigInt, toNormalizedBN} from '@yearn-finance/web-lib/utils/format.bigNumber';
+import {parseUnits, toBigInt, toNormalizedBN, toNormalizedValue} from '@yearn-finance/web-lib/utils/format.bigNumber';
 import {formatAmount} from '@yearn-finance/web-lib/utils/format.number';
 import {ImageWithFallback} from '@common/ImageWithFallback';
 
@@ -29,22 +30,34 @@ type TTokenAmountInput = {
 	showPercentButtons?: boolean;
 	onSetValue: (value: Partial<TSendInputElement>) => void;
 	value: TSendInputElement;
+	/**
+	 * Should be present if we want to make use of query params syncing
+	 */
+	initialValue?: Partial<{amount: bigint; token: TToken}>;
 };
 
 const percentIntervals = [25, 50, 75];
 
-export function SmolTokenAmountInput({showPercentButtons = false, onSetValue, value}: TTokenAmountInput): ReactElement {
+export function SmolTokenAmountInput({
+	showPercentButtons = false,
+	onSetValue,
+	value,
+	initialValue
+}: TTokenAmountInput): ReactElement {
 	const [isFocused, set_isFocused] = useState<boolean>(false);
 
 	const {onOpenCurtain} = useBalancesCurtain();
 
-	const {getBalance} = useWallet();
+	const {getBalance, isLoading} = useWallet();
 
 	const {token} = value;
 
 	const selectedTokenBalance = token ? getBalance(token.address) : toNormalizedBN(0);
+	const initialTokenBalance = initialValue?.token?.address
+		? getBalance(initialValue?.token.address)
+		: toNormalizedBN(0);
 
-	const onChange = (amount: string): void => {
+	const onChange = (amount: string, balance: TNormalizedBN, token?: TToken): void => {
 		if (amount === '') {
 			return onSetValue({
 				amount,
@@ -57,7 +70,7 @@ export function SmolTokenAmountInput({showPercentButtons = false, onSetValue, va
 		if (+amount > 0) {
 			const inputBigInt = amount ? parseUnits(amount, token?.decimals || 18) : toBigInt(0);
 
-			if (inputBigInt > selectedTokenBalance.raw) {
+			if (inputBigInt > balance.raw && !isLoading) {
 				return onSetValue({
 					amount,
 					normalizedBigAmount: toNormalizedBN(inputBigInt, token?.decimals || 18),
@@ -100,14 +113,13 @@ export function SmolTokenAmountInput({showPercentButtons = false, onSetValue, va
 		});
 	};
 
-	const onSelectToken = (token: TToken): void => {
+	const onSelectToken = (valueBigInt: bigint, token: TToken): void => {
 		const tokenBalance = getBalance(token.address);
-		const inputBigInt = parseUnits(value.amount, token?.decimals || 18);
 
-		if (tokenBalance.raw < inputBigInt) {
+		if (tokenBalance.raw < valueBigInt) {
 			return onSetValue({
 				token,
-				normalizedBigAmount: toNormalizedBN(inputBigInt, token?.decimals || 18),
+				normalizedBigAmount: toNormalizedBN(valueBigInt, token?.decimals || 18),
 				isValid: false,
 				error: 'Insufficient balance'
 			});
@@ -115,7 +127,7 @@ export function SmolTokenAmountInput({showPercentButtons = false, onSetValue, va
 
 		onSetValue({
 			token,
-			normalizedBigAmount: toNormalizedBN(inputBigInt, token?.decimals || 18),
+			normalizedBigAmount: toNormalizedBN(valueBigInt, token?.decimals || 18),
 			isValid: true,
 			error: undefined
 		});
@@ -130,6 +142,20 @@ export function SmolTokenAmountInput({showPercentButtons = false, onSetValue, va
 		}
 		return 'border-neutral-400';
 	}, [isFocused, value.isValid]);
+
+	useDeepCompareEffect(() => {
+		if (!initialValue) {
+			return;
+		}
+		if (initialValue.amount && initialValue.token?.address) {
+			const normalizedAmount = toNormalizedValue(
+				initialValue.amount,
+				initialValue?.token?.decimals || 18
+			).toString();
+			onSelectToken(initialValue.amount, initialValue.token);
+			onChange(normalizedAmount, initialTokenBalance, initialValue.token);
+		}
+	}, [initialValue, initialTokenBalance]);
 
 	return (
 		<div className={'relative h-full w-full rounded-lg'}>
@@ -151,7 +177,7 @@ export function SmolTokenAmountInput({showPercentButtons = false, onSetValue, va
 						type={'number'}
 						placeholder={'0.00'}
 						value={value.amount}
-						onChange={e => onChange(e.target.value)}
+						onChange={e => onChange(e.target.value, selectedTokenBalance, token)}
 						max={selectedTokenBalance.normalized}
 						onFocus={() => set_isFocused(true)}
 						onBlur={() => set_isFocused(false)}
@@ -202,7 +228,9 @@ export function SmolTokenAmountInput({showPercentButtons = false, onSetValue, va
 						'flex items-center gap-4 rounded-lg p-4 max-w-[176px] w-full',
 						'bg-neutral-200 hover:bg-neutral-300 transition-colors'
 					)}
-					onClick={() => onOpenCurtain(onSelectToken)}>
+					onClick={() =>
+						onOpenCurtain(token => onSelectToken(parseUnits(value.amount, token?.decimals || 18), token))
+					}>
 					<div className={'flex w-full max-w-[116px] items-center gap-2'}>
 						<ImageWithFallback
 							alt={token?.symbol || ''}

--- a/components/sections/Send/SendWarning.tsx
+++ b/components/sections/Send/SendWarning.tsx
@@ -5,12 +5,12 @@ import {getIsSmartContract, isNullAddress} from '@utils/tools.address';
 import {useChainID} from '@yearn-finance/web-lib/hooks/useChainID';
 import {Warning} from '@common/Primitives/Warning';
 
-import {useSend} from './useSend';
+import {useSendFlow} from './useSendFlow';
 
 import type {ReactElement} from 'react';
 
 export function SendWarning({isReceiverERC20}: {isReceiverERC20: boolean}): ReactElement | null {
-	const {configuration} = useSend();
+	const {configuration} = useSendFlow();
 	const {safeChainID} = useChainID();
 
 	const [warningMessage, set_warningMessage] = useState<string | null>(null);

--- a/components/sections/Send/Wizard.tsx
+++ b/components/sections/Send/Wizard.tsx
@@ -16,7 +16,7 @@ import {getNetwork} from '@yearn-finance/web-lib/utils/wagmi/utils';
 import {defaultTxStatus, type TTxResponse} from '@yearn-finance/web-lib/utils/web3/transaction';
 import {SuccessModal} from '@common/ConfirmationModal';
 
-import {useSend} from './useSend';
+import {useSendFlow} from './useSendFlow';
 
 import type {TSendInputElement} from 'components/designSystem/SmolTokenAmountInput';
 import type {ReactElement} from 'react';
@@ -32,7 +32,7 @@ export function SendWizard({isReceiverERC20}: {isReceiverERC20: boolean}): React
 	const {safeChainID} = useChainID();
 	const {address} = useWeb3();
 
-	const {configuration, dispatchConfiguration} = useSend();
+	const {configuration, dispatchConfiguration} = useSendFlow();
 	const {balances, refresh, balancesNonce} = useWallet();
 	const {isWalletSafe, provider} = useWeb3();
 	const {sdk} = useSafeAppsSDK();

--- a/components/sections/Send/index.tsx
+++ b/components/sections/Send/index.tsx
@@ -8,7 +8,7 @@ import {IconSpinner} from '@icons/IconSpinner';
 import {cl} from '@yearn-finance/web-lib/utils/cl';
 
 import {SendWarning} from './SendWarning';
-import {useSend} from './useSend';
+import {useSendFlow} from './useSendFlow';
 import {SendWizard} from './Wizard';
 
 import type {TInputAddressLike} from 'components/designSystem/SmolAddressInput';
@@ -16,7 +16,7 @@ import type {TSendInputElement} from 'components/designSystem/SmolTokenAmountInp
 import type {ReactElement} from 'react';
 
 function SendTokenRow({input}: {input: TSendInputElement}): ReactElement {
-	const {configuration, dispatchConfiguration} = useSend();
+	const {configuration, dispatchConfiguration} = useSendFlow();
 
 	const onSetValue = (value: Partial<TSendInputElement>): void => {
 		dispatchConfiguration({type: 'SET_VALUE', payload: {...value, UUID: input.UUID}});
@@ -64,7 +64,7 @@ function SendTokenRow({input}: {input: TSendInputElement}): ReactElement {
 }
 
 export function Send(): ReactElement {
-	const {configuration, dispatchConfiguration} = useSend();
+	const {configuration, dispatchConfiguration} = useSendFlow();
 
 	const {tokenList} = useTokenList();
 

--- a/components/sections/Send/useSendFlow.tsx
+++ b/components/sections/Send/useSendFlow.tsx
@@ -1,6 +1,8 @@
 import React, {createContext, useContext, useMemo, useReducer} from 'react';
 import {defaultInputAddressLike} from 'components/designSystem/SmolAddressInput';
+import {useSyncUrlParams} from 'hooks/useSyncUrlParams';
 import {optionalRenderProps} from '@utils/react/optionalRenderProps';
+import {isString} from '@utils/types/typeGuards';
 import {toNormalizedBN} from '@yearn-finance/web-lib/utils/format.bigNumber';
 
 import type {TInputAddressLike} from 'components/designSystem/SmolAddressInput';
@@ -79,6 +81,17 @@ export const SendContextApp = ({children}: {children: TOptionalRenderProps<TSend
 	};
 
 	const [configuration, dispatch] = useReducer(configurationReducer, defaultProps.configuration);
+
+	/**
+	 * Update the url query on every change in the UI
+	 */
+	useSyncUrlParams({
+		to: configuration.receiver.address,
+		tokens: configuration.inputs.map(input => input.token?.address).filter(isString),
+		values: configuration.inputs
+			.map(input => (input.amount === '' ? undefined : input.normalizedBigAmount?.raw.toString()))
+			.filter(isString)
+	});
 
 	const contextValue = useMemo(
 		(): TSend => ({

--- a/components/sections/Send/useSendFlow.tsx
+++ b/components/sections/Send/useSendFlow.tsx
@@ -93,7 +93,7 @@ export const SendContextApp = ({children}: {children: TOptionalRenderProps<TSend
 	);
 };
 
-export const useSend = (): TSend => {
+export const useSendFlow = (): TSend => {
 	const ctx = useContext(SendContext);
 	if (!ctx) {
 		throw new Error('SendContext not found');

--- a/hooks/useSyncUrlParams.ts
+++ b/hooks/useSyncUrlParams.ts
@@ -1,0 +1,31 @@
+import {useRouter} from 'next/router';
+import {useDeepCompareEffect} from '@react-hookz/web';
+import {getPathWithoutQueryParams} from '@utils/url/getPathWithoutQueryParams';
+import {serializeSearchStateForUrl} from '@utils/url/serializeStateForUrl';
+
+export function useSyncUrlParams(
+	state: {[key: string]: unknown},
+	options?: {
+		/**
+		 * These keys will always be serialized, even if they have a falsy value.
+		 */
+		forceSerializeKeys: string[];
+	}
+): void {
+	const {forceSerializeKeys = []} = options ?? {};
+
+	const router = useRouter();
+	useDeepCompareEffect(() => {
+		router.push(
+			{
+				pathname: getPathWithoutQueryParams(router.asPath),
+				query: serializeSearchStateForUrl({...state}, forceSerializeKeys)
+			},
+			undefined,
+			{
+				scroll: false,
+				shallow: true
+			}
+		);
+	}, [forceSerializeKeys, router.isReady, state]);
+}

--- a/pages/apps/send.tsx
+++ b/pages/apps/send.tsx
@@ -3,15 +3,17 @@ import {Send} from 'components/sections/Send';
 import {SendContextApp} from 'components/sections/Send/useSendFlow';
 import {BalancesCurtainContextApp} from 'contexts/useBalancesCurtain';
 
+import type {NextPageContext} from 'next';
+import type {ParsedUrlQuery} from 'querystring';
 import type {ReactElement} from 'react';
 
-export default function SendPage(): ReactElement {
+export default function SendPage({pageProps}: {pageProps: {query: ParsedUrlQuery}}): ReactElement {
 	return (
 		<SendContextApp>
 			{({configuration: {inputs}}) => (
 				<BalancesCurtainContextApp
 					selectedTokenAddresses={inputs.map(input => input.token?.address).filter(Boolean)}>
-					<Send />
+					<Send queryParams={pageProps.query} />
 				</BalancesCurtainContextApp>
 			)}
 		</SendContextApp>
@@ -22,4 +24,9 @@ SendPage.AppName = 'Send';
 SendPage.AppDescription = 'Deliver any of your tokens anywhere';
 SendPage.getLayout = function getLayout(page: ReactElement): ReactElement {
 	return <Fragment>{page}</Fragment>;
+};
+SendPage.getInitialProps = (context: NextPageContext): {query: ParsedUrlQuery} => {
+	return {
+		query: context.query
+	};
 };

--- a/pages/apps/send.tsx
+++ b/pages/apps/send.tsx
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 import {Send} from 'components/sections/Send';
-import {SendContextApp} from 'components/sections/Send/useSend';
+import {SendContextApp} from 'components/sections/Send/useSendFlow';
 import {BalancesCurtainContextApp} from 'contexts/useBalancesCurtain';
 
 import type {ReactElement} from 'react';

--- a/utils/types/typeGuards.ts
+++ b/utils/types/typeGuards.ts
@@ -1,0 +1,7 @@
+export function isNonNullable<T>(value: T): value is NonNullable<T> {
+	return value !== null && value !== undefined;
+}
+
+export function isString(value: unknown): value is string {
+	return typeof value === 'string';
+}

--- a/utils/types/types.tsx
+++ b/utils/types/types.tsx
@@ -53,3 +53,8 @@ export type TTokenWithAmount = TToken & {
 };
 
 export type TModify<TOriginal, TModification> = Omit<TOriginal, keyof TModification> & TModification;
+
+/**
+ * Acts like Partial, but requires all properties to be explicity set to undefined if missing.
+ */
+export type TPartialExhaustive<T> = {[Key in keyof T]: T[Key] | undefined};

--- a/utils/url/getParamFromUrlQuery.ts
+++ b/utils/url/getParamFromUrlQuery.ts
@@ -1,0 +1,39 @@
+import {isString} from '@utils/types/typeGuards';
+
+import type {ParsedUrlQuery} from 'querystring';
+
+type TGetParamFromUrlQuery<TDefault, TResult> = (key: string, defaultValue?: TDefault) => TResult;
+
+type TGetStringParamFromUrlQuery = TGetParamFromUrlQuery<string | undefined, string | undefined>;
+
+export function getStringParamFromUrlQuery(query: ParsedUrlQuery): TGetStringParamFromUrlQuery {
+	return (key: string, defaultValue?: string) => {
+		const param = query[key];
+		if (isString(param) && param.length > 0) {
+			return param;
+		}
+		return defaultValue;
+	};
+}
+
+type TGetArrayParamFromUrlQuery = TGetParamFromUrlQuery<[] | undefined, string[] | undefined>;
+
+export function getArrayParamFromUrlQuery(query: ParsedUrlQuery): TGetArrayParamFromUrlQuery {
+	return (key: string, defaultValue?: []) => {
+		const param = query[key];
+		if (Array.isArray(param)) {
+			return param;
+		}
+		if (isString(param)) {
+			return param.split(',');
+		}
+		return defaultValue;
+	};
+}
+
+export function getParamFromUrlQuery(query: ParsedUrlQuery): {
+	string: TGetStringParamFromUrlQuery;
+	array: TGetArrayParamFromUrlQuery;
+} {
+	return {string: getStringParamFromUrlQuery(query), array: getArrayParamFromUrlQuery(query)};
+}

--- a/utils/url/getPathWithoutQueryParams.ts
+++ b/utils/url/getPathWithoutQueryParams.ts
@@ -1,0 +1,7 @@
+/**
+ * Strips the query params from a URL if present
+ */
+export function getPathWithoutQueryParams(path: string): string {
+	const pathParts = path.split('?');
+	return pathParts[0];
+}

--- a/utils/url/getStateFromUrlQuery.ts
+++ b/utils/url/getStateFromUrlQuery.ts
@@ -1,0 +1,15 @@
+import {getParamFromUrlQuery} from './getParamFromUrlQuery';
+
+import type {ParsedUrlQuery} from 'querystring';
+import type {TPartialExhaustive} from '@utils/types/types';
+
+/**
+ * Uses the `getParamFromUrl` helpers to get state value from URL query params based on a state schema.
+ *
+ */
+export function getStateFromUrlQuery<TState>(
+	query: ParsedUrlQuery,
+	callback: (helpers: ReturnType<typeof getParamFromUrlQuery>) => TPartialExhaustive<TState>
+): Partial<TState> {
+	return callback(getParamFromUrlQuery(query));
+}

--- a/utils/url/serializeStateForUrl.ts
+++ b/utils/url/serializeStateForUrl.ts
@@ -1,0 +1,36 @@
+import {isNonNullable} from '@utils/types/typeGuards';
+
+/**
+ * Converts a state object into a query params string that can be used in an URL.
+ *
+ * It is a generic helper.
+ */
+export function serializeSearchStateForUrl(
+	state: {[key: string]: unknown},
+	/**
+	 * These keys will always be serialized, even if they have a falsy value.
+	 */
+	forceSerializeKeys: string[] = []
+): string {
+	const mappedStateEntries = Object.entries(state).map(([key, value]) => {
+		if (!value && !forceSerializeKeys.includes(key)) {
+			return undefined;
+		}
+
+		if (Array.isArray(value)) {
+			if (value.length === 0) {
+				return undefined;
+			}
+			if (!['string', 'number', 'bigint', 'boolean'].includes(typeof value[0])) {
+				return undefined;
+			}
+			return `${key}=${value.join(',')}`;
+		}
+
+		return `${key}=${value}`;
+	});
+
+	const filteredStateEntries = mappedStateEntries.filter(isNonNullable);
+
+	return encodeURI(filteredStateEntries.join('&'));
+}


### PR DESCRIPTION
Added 2 way syncing here, so now you should be able to see that the data is taken from the url query when accessing the page (if there is any data).
It's also possible to refresh the page without data disappearing.

I'm not a fan of how I retrieve the data from the url. The way I do it here is just to get the query in `SendPage.getInitialProps` and `set` the data inside of the `SmolAddressInput` and `SmolTokenAmountInput` components. The best approach here would be to do smth like that - 
`initialSendState = {...defaultState, ...stateFromUrl}`, but this way we would skip all the validation for the `receiver` (AB checks, ens etc), and the same goes for tokens (token balance, address validity etc).

Please take a look at this and don't hesitate offering me a better approach for this if you come up with one 😃