### PR TITLE
feat: remove server dep & cleanup

### DIFF
--- a/components/apps/migrate/index.tsx
+++ b/components/apps/migrate/index.tsx
@@ -10,8 +10,8 @@ import TokenInput from '@common/TokenInput';
 import {useMigrate} from './useMigrate';
 import {MigrateWizard} from './Wizard';
 
-import type {TInputAddressLike} from 'components/designSystem/SmolAddressInput';
 import type {ReactElement} from 'react';
+import type {TInputAddressLike} from '@utils/tools.address';
 import type {TToken} from '@utils/types/types';
 
 function MigrateTokenRow(props: {index: number; token: TToken}): ReactElement {

--- a/components/apps/migrate/useMigrate.tsx
+++ b/components/apps/migrate/useMigrate.tsx
@@ -3,10 +3,10 @@ import {useUpdateEffect} from '@react-hookz/web';
 import {isZeroAddress} from '@utils/tools.address';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 
-import type {TInputAddressLike} from 'components/designSystem/SmolAddressInput';
 import type {Dispatch} from 'react';
 import type {TAddress, TDict} from '@yearn-finance/web-lib/types';
 import type {TNormalizedBN} from '@yearn-finance/web-lib/utils/format.bigNumber';
+import type {TInputAddressLike} from '@utils/tools.address';
 import type {TToken} from '@utils/types/types';
 
 export type TMigrateElement = TToken & {

--- a/components/apps/nftmigratooor/1.ViewDestination.tsx
+++ b/components/apps/nftmigratooor/1.ViewDestination.tsx
@@ -1,13 +1,12 @@
 import React, {useState} from 'react';
 import AddressInput from 'components/common/AddressInput';
-import {defaultInputAddressLike} from 'components/designSystem/SmolAddressInput';
 import {Button} from 'components/Primitives/Button';
 import {useNFTMigratooor} from '@nftmigratooor/useNFTMigratooor';
-import {isZeroAddress, toAddress} from '@utils/tools.address';
+import {defaultInputAddressLike, isZeroAddress, toAddress} from '@utils/tools.address';
 import ViewSectionHeading from '@common/ViewSectionHeading';
 
-import type {TInputAddressLike} from 'components/designSystem/SmolAddressInput';
 import type {ReactElement} from 'react';
+import type {TInputAddressLike} from '@utils/tools.address';
 
 type TViewDestinationProps = {
 	onProceed: () => void;

--- a/components/apps/safe/Sections.tsx
+++ b/components/apps/safe/Sections.tsx
@@ -1,12 +1,11 @@
 import React, {useCallback, useState} from 'react';
 import assert from 'assert';
 import ChainStatus from 'components/apps/safe/ChainStatus';
-import {defaultInputAddressLike} from 'components/designSystem/SmolAddressInput';
 import {Button} from 'components/Primitives/Button';
 import IconSquareMinus from '@icons/IconSquareMinus';
 import IconSquarePlus from '@icons/IconSquarePlus';
 import IconWarning from '@icons/IconWarning';
-import {isZeroAddress, toAddress} from '@utils/tools.address';
+import {defaultInputAddressLike, isZeroAddress, toAddress} from '@utils/tools.address';
 import {supportedNetworks, supportedTestNetworks} from '@utils/tools.chains';
 import {fetchTransaction} from '@wagmi/core';
 import {AddressLike} from '@yearn-finance/web-lib/components/AddressLike';
@@ -20,10 +19,9 @@ import {Label} from '@common/Label';
 import {newVoidOwner, useMultiSafe} from './useSafe';
 import {CALL_INIT_SIGNATURE, decodeArgInitializers, retrieveSafeTxHash, SINGLETON_L2, SINGLETON_L2_DDP} from './utils';
 
-import type {TInputAddressLike} from 'components/designSystem/SmolAddressInput';
 import type {ReactElement} from 'react';
 import type {Hex} from 'viem';
-import type {TAddress} from '@utils/tools.address';
+import type {TAddress, TInputAddressLike} from '@utils/tools.address';
 import type {TOwners} from './types';
 
 export function SectionDisplayOwners(): ReactElement {

--- a/components/apps/stream/3.ViewUserStreams.tsx
+++ b/components/apps/stream/3.ViewUserStreams.tsx
@@ -1,16 +1,15 @@
 import React, {useEffect, useState} from 'react';
-import {defaultInputAddressLike} from 'components/designSystem/SmolAddressInput';
 import {Button} from 'components/Primitives/Button';
 import {IconSpinner} from '@icons/IconSpinner';
-import {isZeroAddress, toAddress} from '@utils/tools.address';
+import {defaultInputAddressLike, isZeroAddress, toAddress} from '@utils/tools.address';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 import AddressInput from '@common/AddressInput';
 
 import {useUserStreams} from './useUserStreams';
 import {VestingElement} from './VestingElement';
 
-import type {TInputAddressLike} from 'components/designSystem/SmolAddressInput';
 import type {ReactElement} from 'react';
+import type {TInputAddressLike} from '@utils/tools.address';
 
 function ViewUserStreams(): ReactElement {
 	const {address, ens} = useWeb3();

--- a/components/apps/stream/useStream.tsx
+++ b/components/apps/stream/useStream.tsx
@@ -1,13 +1,14 @@
 import React, {createContext, useContext, useEffect, useMemo, useReducer, useState} from 'react';
-import {defaultInputAddressLike, type TInputAddressLike} from 'components/designSystem/SmolAddressInput';
 import {isBefore} from 'date-fns';
 import {scrollToTargetAdjusted} from 'utils/animations';
 import {HEADER_HEIGHT} from 'utils/constants';
 import {useUpdateEffect} from '@react-hookz/web';
+import {defaultInputAddressLike} from '@utils/tools.address';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 
 import type {Dispatch, SetStateAction} from 'react';
 import type {TNormalizedBN} from '@yearn-finance/web-lib/utils/format.bigNumber';
+import type {TInputAddressLike} from '@utils/tools.address';
 import type {TToken} from '@utils/types/types';
 
 export enum Step {

--- a/components/apps/stream/useUserStreams.tsx
+++ b/components/apps/stream/useUserStreams.tsx
@@ -7,8 +7,7 @@ import {getClient} from '@yearn-finance/web-lib/utils/wagmi/utils';
 
 import {getVestingContracts} from './constants';
 
-import type {TInputAddressLike} from 'components/designSystem/SmolAddressInput';
-import type {TAddress} from '@utils/tools.address';
+import type {TAddress, TInputAddressLike} from '@utils/tools.address';
 
 export type TStreamArgs = {
 	funder: TAddress;

--- a/components/common/AddressInput.tsx
+++ b/components/common/AddressInput.tsx
@@ -8,8 +8,8 @@ import {IconLoader} from '@yearn-finance/web-lib/icons/IconLoader';
 import {cl} from '@yearn-finance/web-lib/utils/cl';
 import {ZERO_ADDRESS} from '@yearn-finance/web-lib/utils/constants';
 
-import type {TInputAddressLike} from 'components/designSystem/SmolAddressInput';
 import type {ReactElement} from 'react';
+import type {TInputAddressLike} from '@utils/tools.address';
 
 export type TAddressInput = {
 	value: TInputAddressLike;

--- a/components/common/TokenList/TokenListAddBox.tsx
+++ b/components/common/TokenList/TokenListAddBox.tsx
@@ -1,9 +1,9 @@
 import React, {useCallback, useMemo, useRef, useState} from 'react';
-import {defaultInputAddressLike} from 'components/designSystem/SmolAddressInput';
 import {Button} from 'components/Primitives/Button';
 import axios from 'axios';
 import {IconCircleCheck} from '@icons/IconCircleCheck';
 import {IconCircleCross} from '@icons/IconCircleCross';
+import {defaultInputAddressLike} from '@utils/tools.address';
 import {erc20ABI, readContracts} from '@wagmi/core';
 import {useChainID} from '@yearn-finance/web-lib/hooks/useChainID';
 import {IconLoader} from '@yearn-finance/web-lib/icons/IconLoader';
@@ -11,7 +11,7 @@ import {decodeAsBigInt, decodeAsNumber, decodeAsString} from '@yearn-finance/web
 import {toNormalizedBN} from '@yearn-finance/web-lib/utils/format.bigNumber';
 import AddressInput from '@common/AddressInput';
 
-import type {TInputAddressLike} from 'components/designSystem/SmolAddressInput';
+import type {TInputAddressLike} from '@utils/tools.address';
 import type {TToken, TTokenList} from '@utils/types/types';
 
 type TValue = {

--- a/components/designSystem/Curtains/AddressBookCurtain.tsx
+++ b/components/designSystem/Curtains/AddressBookCurtain.tsx
@@ -21,8 +21,7 @@ import {SmolAddressInputSimple} from '../SmolAddressInput.simple';
 
 import type {TAddressBookEntryReducer} from 'pages/apps/address-book';
 import type {Dispatch, ReactElement, SetStateAction} from 'react';
-import type {TAddress} from '@utils/tools.address';
-import type {TInputAddressLike} from '../SmolAddressInput';
+import type {TAddress, TInputAddressLike} from '@utils/tools.address';
 
 function EntryAvatarWrapper(props: {address: TAddress}): ReactElement {
 	const {data: ensName} = useEnsName({

--- a/components/designSystem/SmolAddressInput.simple.tsx
+++ b/components/designSystem/SmolAddressInput.simple.tsx
@@ -3,17 +3,14 @@ import {getEnsName} from 'viem/ens';
 import {IconCircleCheck} from '@icons/IconCircleCheck';
 import {IconCircleCross} from '@icons/IconCircleCross';
 import {useAsyncAbortable, useUpdateEffect} from '@react-hookz/web';
-import {isAddress, toAddress, truncateHex} from '@utils/tools.address';
+import {defaultInputAddressLike, isAddress, toAddress, truncateHex} from '@utils/tools.address';
 import {checkENSValidity} from '@utils/tools.ens';
 import {getPublicClient} from '@wagmi/core';
 import {IconLoader} from '@yearn-finance/web-lib/icons/IconLoader';
 import {cl} from '@yearn-finance/web-lib/utils/cl';
 
-import {defaultInputAddressLike} from './SmolAddressInput';
-
 import type {InputHTMLAttributes, ReactElement, RefObject} from 'react';
-import type {TAddress} from '@utils/tools.address';
-import type {TInputAddressLike} from './SmolAddressInput';
+import type {TAddress, TInputAddressLike} from '@utils/tools.address';
 
 export function SmolAddressInputSimple(
 	props: {

--- a/components/designSystem/SmolAddressInput.tsx
+++ b/components/designSystem/SmolAddressInput.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useSendFlow} from 'components/sections/Send/useSendFlow';
 import {useAddressBook} from 'contexts/useAddressBook';
 import {getEnsName} from 'viem/ens';
 import {IconAppAddressBook} from '@icons/IconApps';
@@ -6,7 +7,7 @@ import {IconChevron} from '@icons/IconChevron';
 import {IconCircleCheck} from '@icons/IconCircleCheck';
 import {IconCircleCross} from '@icons/IconCircleCross';
 import {useAsyncAbortable} from '@react-hookz/web';
-import {isAddress, toAddress, truncateHex} from '@utils/tools.address';
+import {defaultInputAddressLike, isAddress, toAddress, truncateHex} from '@utils/tools.address';
 import {checkENSValidity} from '@utils/tools.ens';
 import {getPublicClient} from '@wagmi/core';
 import {IconLoader} from '@yearn-finance/web-lib/icons/IconLoader';
@@ -14,33 +15,16 @@ import {cl} from '@yearn-finance/web-lib/utils/cl';
 
 import type {TAddressBookEntry} from 'contexts/useAddressBook';
 import type {ReactElement} from 'react';
-import type {TAddress} from '@utils/tools.address';
-
-export type TInputAddressLike = {
-	address: TAddress | undefined;
-	label: string;
-	isValid: boolean | 'undetermined';
-	source?: 'typed' | 'addressBook' | 'defaultValue' | 'urlQuery';
-	error?: string;
-};
-export const defaultInputAddressLike: TInputAddressLike = {
-	address: undefined,
-	label: '',
-	isValid: 'undetermined',
-	source: 'typed'
-};
+import type {TAddress, TInputAddressLike} from '@utils/tools.address';
 
 type TAddressInput = {
 	onSetValue: (value: TInputAddressLike) => void;
 	value: TInputAddressLike;
-	/**
-	 * Should be present if we want to make use of query params syncing
-	 */
-	initialValue?: string;
 };
 
-export function SmolAddressInput({onSetValue, value, initialValue}: TAddressInput): ReactElement {
+export function SmolAddressInput({onSetValue, value}: TAddressInput): ReactElement {
 	const {onOpenCurtain, getEntry, getCachedEntry} = useAddressBook();
+	const {initialStateFromUrl} = useSendFlow();
 	const [isFocused, set_isFocused] = useState<boolean>(false);
 	const [isCheckingValidity, set_isCheckingValidity] = useState<boolean>(false);
 
@@ -177,11 +161,11 @@ export function SmolAddressInput({onSetValue, value, initialValue}: TAddressInpu
 	);
 
 	useEffect(() => {
-		if (!initialValue) {
+		if (!initialStateFromUrl?.to) {
 			return;
 		}
-		onChange(initialValue);
-	}, []);
+		onChange(initialStateFromUrl.to);
+	}, [initialStateFromUrl, initialStateFromUrl?.to, onChange]);
 
 	const onSelectItem = useCallback((item: TAddressBookEntry): void => {
 		currentInput.current = item.label || item.ens || toAddress(item.address);

--- a/components/designSystem/SmolTokenAmountInput.tsx
+++ b/components/designSystem/SmolTokenAmountInput.tsx
@@ -30,9 +30,6 @@ type TTokenAmountInput = {
 	showPercentButtons?: boolean;
 	onSetValue: (value: Partial<TSendInputElement>) => void;
 	value: TSendInputElement;
-	/**
-	 * Should be present if we want to make use of query params syncing
-	 */
 	initialValue?: Partial<{amount: bigint; token: TToken}>;
 };
 

--- a/components/sections/Send/useSendQuery.ts
+++ b/components/sections/Send/useSendQuery.ts
@@ -1,0 +1,23 @@
+import {useMemo} from 'react';
+import {useRouter} from 'next/router';
+import {getStateFromUrlQuery} from '@utils/url/getStateFromUrlQuery';
+
+import type {TSendQuery} from 'components/sections/Send/useSendFlow';
+
+export function useSendQuery(): {initialStateFromUrl: TSendQuery | null; stateFromUrl: TSendQuery} {
+	const router = useRouter();
+	const searchParams = new URLSearchParams(router.asPath.split('?')[1]);
+
+	const queryParams = Object.fromEntries(searchParams.entries());
+	const stateFromUrl = getStateFromUrlQuery<TSendQuery>(queryParams, ({string, array}) => ({
+		to: string('to'),
+		tokens: array('tokens'),
+		values: array('values')
+	}));
+
+	const initialStateFromUrl = useMemo(() => {
+		return stateFromUrl;
+	}, []);
+
+	return {initialStateFromUrl, stateFromUrl};
+}

--- a/hooks/useSyncUrlParams.ts
+++ b/hooks/useSyncUrlParams.ts
@@ -3,23 +3,14 @@ import {useDeepCompareEffect} from '@react-hookz/web';
 import {getPathWithoutQueryParams} from '@utils/url/getPathWithoutQueryParams';
 import {serializeSearchStateForUrl} from '@utils/url/serializeStateForUrl';
 
-export function useSyncUrlParams(
-	state: {[key: string]: unknown},
-	options?: {
-		/**
-		 * These keys will always be serialized, even if they have a falsy value.
-		 */
-		forceSerializeKeys: string[];
-	}
-): void {
-	const {forceSerializeKeys = []} = options ?? {};
-
+export function useSyncUrlParams(state: {[key: string]: unknown}): void {
 	const router = useRouter();
+
 	useDeepCompareEffect(() => {
-		router.push(
+		router.replace(
 			{
 				pathname: getPathWithoutQueryParams(router.asPath),
-				query: serializeSearchStateForUrl({...state}, forceSerializeKeys)
+				query: serializeSearchStateForUrl(state)
 			},
 			undefined,
 			{
@@ -27,5 +18,5 @@ export function useSyncUrlParams(
 				shallow: true
 			}
 		);
-	}, [forceSerializeKeys, router.isReady, state]);
+	}, [state]);
 }

--- a/pages/apps/send.tsx
+++ b/pages/apps/send.tsx
@@ -3,17 +3,15 @@ import {Send} from 'components/sections/Send';
 import {SendContextApp} from 'components/sections/Send/useSendFlow';
 import {BalancesCurtainContextApp} from 'contexts/useBalancesCurtain';
 
-import type {NextPageContext} from 'next';
-import type {ParsedUrlQuery} from 'querystring';
 import type {ReactElement} from 'react';
 
-export default function SendPage({pageProps}: {pageProps: {query: ParsedUrlQuery}}): ReactElement {
+export default function SendPage(): ReactElement {
 	return (
 		<SendContextApp>
 			{({configuration: {inputs}}) => (
 				<BalancesCurtainContextApp
 					selectedTokenAddresses={inputs.map(input => input.token?.address).filter(Boolean)}>
-					<Send queryParams={pageProps.query} />
+					<Send />
 				</BalancesCurtainContextApp>
 			)}
 		</SendContextApp>
@@ -24,9 +22,4 @@ SendPage.AppName = 'Send';
 SendPage.AppDescription = 'Deliver any of your tokens anywhere';
 SendPage.getLayout = function getLayout(page: ReactElement): ReactElement {
 	return <Fragment>{page}</Fragment>;
-};
-SendPage.getInitialProps = (context: NextPageContext): {query: ParsedUrlQuery} => {
-	return {
-		query: context.query
-	};
 };

--- a/utils/tools.address.ts
+++ b/utils/tools.address.ts
@@ -11,6 +11,21 @@ export type TAddressWagmi = `0x${string}`;
 export type TAddress = TAddressWagmi;
 export type TAddressLike = TAddressSmol | TAddressWagmi | string;
 
+export type TInputAddressLike = {
+	address: TAddress | undefined;
+	label: string;
+	isValid: boolean | 'undetermined';
+	source?: 'typed' | 'addressBook' | 'defaultValue';
+	error?: string;
+};
+
+export const defaultInputAddressLike: TInputAddressLike = {
+	address: undefined,
+	label: '',
+	isValid: 'undetermined',
+	source: 'typed'
+};
+
 /******************************************************************************
  ** toAddress - Wagmi only requires a 0xString as a valid address. To use our
  ** safest version, we need to convert it between types, and the other way

--- a/utils/url/getStateFromUrlQuery.ts
+++ b/utils/url/getStateFromUrlQuery.ts
@@ -1,7 +1,6 @@
 import {getParamFromUrlQuery} from './getParamFromUrlQuery';
 
 import type {ParsedUrlQuery} from 'querystring';
-import type {TPartialExhaustive} from '@utils/types/types';
 
 /**
  * Uses the `getParamFromUrl` helpers to get state value from URL query params based on a state schema.
@@ -9,7 +8,7 @@ import type {TPartialExhaustive} from '@utils/types/types';
  */
 export function getStateFromUrlQuery<TState>(
 	query: ParsedUrlQuery,
-	callback: (helpers: ReturnType<typeof getParamFromUrlQuery>) => TPartialExhaustive<TState>
-): Partial<TState> {
+	callback: (helpers: ReturnType<typeof getParamFromUrlQuery>) => TState
+): TState {
 	return callback(getParamFromUrlQuery(query));
 }

--- a/utils/url/serializeStateForUrl.ts
+++ b/utils/url/serializeStateForUrl.ts
@@ -5,15 +5,9 @@ import {isNonNullable} from '@utils/types/typeGuards';
  *
  * It is a generic helper.
  */
-export function serializeSearchStateForUrl(
-	state: {[key: string]: unknown},
-	/**
-	 * These keys will always be serialized, even if they have a falsy value.
-	 */
-	forceSerializeKeys: string[] = []
-): string {
+export function serializeSearchStateForUrl(state: {[key: string]: unknown}): string {
 	const mappedStateEntries = Object.entries(state).map(([key, value]) => {
-		if (!value && !forceSerializeKeys.includes(key)) {
+		if (!value) {
 			return undefined;
 		}
 


### PR DESCRIPTION
Sticked to previous url sync imp here because I feel it should be way easier to reuse for different apps:
- no need to call the `updateUrl` function on every ui change
- way easier to handle multiple inputs data (I may be stupid but it didn't work out in `useQueryArg` imp 🥲)`
- we should only consider adding `useSendQuery` alike hook to be able to work with other apps (this can be abstracted as well but feels a bit weird to do)